### PR TITLE
feat: include leader's public key when adding funds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nilvm"]
 	path = nilvm
-	url = git@github.com:NillionNetwork/nilvm.git
+	url = https://github.com/NillionNetwork/nilvm

--- a/.nil-sdk.toml
+++ b/.nil-sdk.toml
@@ -1,1 +1,1 @@
-version = "v0.10.0-rc.23"
+version = "v0.10.0-rc.39"

--- a/client-proto/src/nillion_client_proto/nillion/payments/v1/balance/__init__.py
+++ b/client-proto/src/nillion_client_proto/nillion/payments/v1/balance/__init__.py
@@ -8,7 +8,10 @@ from datetime import datetime
 
 import betterproto
 
-from ....auth.v1 import user as ___auth_v1_user__
+from ....auth.v1 import (
+    public_key as ___auth_v1_public_key__,
+    user as ___auth_v1_user__,
+)
 
 
 @dataclass(eq=False, repr=False)
@@ -47,3 +50,8 @@ class AddFundsPayload(betterproto.Message):
     """
     A 32 byte nonce that is used to add entropy to the hash of this message and to prevent duplicate spending.
     """
+
+    leader_public_key: "___auth_v1_public_key__.PublicKey" = betterproto.message_field(
+        3
+    )
+    """The public key of the leader node that funds are being sent to."""

--- a/src/nillion_client/client.py
+++ b/src/nillion_client/client.py
@@ -1415,7 +1415,9 @@ class VmClient:
             )
         nonce = secrets.token_bytes(32)
         payload = AddFundsPayload(
-            recipient=(target_user or self.user_id).to_proto(), nonce=nonce
+            recipient=(target_user or self.user_id).to_proto(),
+            nonce=nonce,
+            leader_public_key=self.cluster.leader.public_key,
         ).SerializeToString()
         payload_hash = hashlib.sha256(payload).digest()
         tx_hash = await self._payer.submit_payment(amount_unil, payload_hash)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [manifest]
@@ -1198,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "nillion-client"
-version = "0.2.1rc1"
+version = "0.2.1rc2"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },
@@ -1271,7 +1272,7 @@ dev = [
 
 [[package]]
 name = "nillion-client-core"
-version = "0.2.1rc1"
+version = "0.2.1rc2"
 source = { editable = "client-core" }
 
 [package.optional-dependencies]
@@ -1285,10 +1286,11 @@ requires-dist = [
     { name = "maturin", extras = ["zig"], marker = "extra == 'dev'", specifier = "==1.7.4" },
     { name = "pip", marker = "extra == 'dev'", specifier = "==24.2" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "nillion-client-proto"
-version = "0.2.1rc1"
+version = "0.2.1rc2"
 source = { editable = "client-proto" }
 dependencies = [
     { name = "betterproto" },
@@ -1308,6 +1310,7 @@ requires-dist = [
     { name = "googleapis-common-protos", specifier = "==1.66.0" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = "==1.62.3" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "nodeenv"


### PR DESCRIPTION
This implements the new leader public key logic for add-funds introduced in https://github.com/NillionNetwork/nilvm/pull/67